### PR TITLE
Feature/ss v5

### DIFF
--- a/src/ServiceStack.Request.Correlation/ServiceStack.Request.Correlation.csproj
+++ b/src/ServiceStack.Request.Correlation/ServiceStack.Request.Correlation.csproj
@@ -34,25 +34,20 @@
       <HintPath>..\packages\RustFlakes.1.4.1\lib\RustFlakes.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack, Version=4.0.56.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.4.0.56\lib\net40\ServiceStack.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ServiceStack, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.5.0.2\lib\net45\ServiceStack.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=4.0.56.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Client.4.0.56\lib\net40\ServiceStack.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ServiceStack.Client, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Client.5.0.2\lib\net45\ServiceStack.Client.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Common, Version=4.0.56.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Common.4.0.56\lib\net40\ServiceStack.Common.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ServiceStack.Common, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Common.5.0.2\lib\net45\ServiceStack.Common.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=4.0.0.0, Culture=neutral, PublicKeyToken=e06fbc6124f57c43, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Interfaces.4.0.56\lib\portable-wp80+sl5+net40+win8+wpa81+monotouch+monoandroid+xamarin.ios10\ServiceStack.Interfaces.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ServiceStack.Interfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Interfaces.5.0.2\lib\net45\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=4.0.56.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ServiceStack.Text.4.0.56\lib\net40\ServiceStack.Text.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ServiceStack.Text, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.Text.5.0.2\lib\net45\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/ServiceStack.Request.Correlation/ServiceStack.Request.Correlation.nuspec
+++ b/src/ServiceStack.Request.Correlation/ServiceStack.Request.Correlation.nuspec
@@ -12,7 +12,7 @@
     <tags>servicestack request correlation microservices</tags>
     <releaseNotes>See github project for details</releaseNotes>
     <dependencies>
-      <dependency id="ServiceStack.Server" version="[4.0.56, 5.0.2]" />
+      <dependency id="ServiceStack.Server" version="[4.0.56, 5.1)" />
       <dependency id="RustFlakes" version="1.4.1" />
     </dependencies>
   </metadata>

--- a/src/ServiceStack.Request.Correlation/ServiceStack.Request.Correlation.nuspec
+++ b/src/ServiceStack.Request.Correlation/ServiceStack.Request.Correlation.nuspec
@@ -12,7 +12,7 @@
     <tags>servicestack request correlation microservices</tags>
     <releaseNotes>See github project for details</releaseNotes>
     <dependencies>
-      <dependency id="ServiceStack.Server" version="[4.0.56, 5)" />
+      <dependency id="ServiceStack.Server" version="[4.0.56, 5.0.2]" />
       <dependency id="RustFlakes" version="1.4.1" />
     </dependencies>
   </metadata>

--- a/src/ServiceStack.Request.Correlation/packages.config
+++ b/src/ServiceStack.Request.Correlation/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="RustFlakes" version="1.4.1" targetFramework="net452" />
-  <package id="ServiceStack" version="4.0.56" targetFramework="net452" />
-  <package id="ServiceStack.Client" version="4.0.56" targetFramework="net452" />
-  <package id="ServiceStack.Common" version="4.0.56" targetFramework="net452" />
-  <package id="ServiceStack.Interfaces" version="4.0.56" targetFramework="net452" />
-  <package id="ServiceStack.Text" version="4.0.56" targetFramework="net452" />
+  <package id="ServiceStack" version="5.0.2" targetFramework="net452" />
+  <package id="ServiceStack.Client" version="5.0.2" targetFramework="net452" />
+  <package id="ServiceStack.Common" version="5.0.2" targetFramework="net452" />
+  <package id="ServiceStack.Interfaces" version="5.0.2" targetFramework="net452" />
+  <package id="ServiceStack.Text" version="5.0.2" targetFramework="net452" />
 </packages>

--- a/test/DemoService/DemoService.csproj
+++ b/test/DemoService/DemoService.csproj
@@ -33,25 +33,20 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ServiceStack, Version=4.0.56.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\src\packages\ServiceStack.4.0.56\lib\net40\ServiceStack.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ServiceStack, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\ServiceStack.5.0.2\lib\net45\ServiceStack.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=4.0.56.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\src\packages\ServiceStack.Client.4.0.56\lib\net40\ServiceStack.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ServiceStack.Client, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\ServiceStack.Client.5.0.2\lib\net45\ServiceStack.Client.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Common, Version=4.0.56.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\src\packages\ServiceStack.Common.4.0.56\lib\net40\ServiceStack.Common.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ServiceStack.Common, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\ServiceStack.Common.5.0.2\lib\net45\ServiceStack.Common.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=4.0.0.0, Culture=neutral, PublicKeyToken=e06fbc6124f57c43, processorArchitecture=MSIL">
-      <HintPath>..\..\src\packages\ServiceStack.Interfaces.4.0.56\lib\portable-wp80+sl5+net40+win8+wpa81+monotouch+monoandroid+xamarin.ios10\ServiceStack.Interfaces.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ServiceStack.Interfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\ServiceStack.Interfaces.5.0.2\lib\net45\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=4.0.56.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\src\packages\ServiceStack.Text.4.0.56\lib\net40\ServiceStack.Text.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ServiceStack.Text, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\ServiceStack.Text.5.0.2\lib\net45\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/test/DemoService/packages.config
+++ b/test/DemoService/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ServiceStack" version="4.0.56" targetFramework="net452" />
-  <package id="ServiceStack.Client" version="4.0.56" targetFramework="net452" />
-  <package id="ServiceStack.Common" version="4.0.56" targetFramework="net452" />
-  <package id="ServiceStack.Interfaces" version="4.0.56" targetFramework="net452" />
-  <package id="ServiceStack.Text" version="4.0.56" targetFramework="net452" />
+  <package id="ServiceStack" version="5.0.2" targetFramework="net452" />
+  <package id="ServiceStack.Client" version="5.0.2" targetFramework="net452" />
+  <package id="ServiceStack.Common" version="5.0.2" targetFramework="net452" />
+  <package id="ServiceStack.Interfaces" version="5.0.2" targetFramework="net452" />
+  <package id="ServiceStack.Text" version="5.0.2" targetFramework="net452" />
 </packages>

--- a/test/ServiceStack.Request.Correlation.Tests/Extensions/RequestExtensionsTests.cs
+++ b/test/ServiceStack.Request.Correlation.Tests/Extensions/RequestExtensionsTests.cs
@@ -9,12 +9,24 @@ namespace ServiceStack.Request.Correlation.Tests.Extensions
     using Testing;
     using Xunit;
 
-    public class RequestExtensionsTests
+    public class RequestExtensionsTests : IDisposable
     {
+        private ServiceStackHost appHost;
+        
         private const string headerName = "x-correlationId";
         private readonly string headerValue = Guid.NewGuid().ToString();
         private readonly string itemValue = Guid.NewGuid().ToString();
 
+        public RequestExtensionsTests()
+        {
+            appHost = new BasicAppHost().Init();
+        }
+ 
+        public void Dispose()
+        {
+            appHost.Dispose();
+        }
+        
         [Fact]
         public void GetCorrelationId_ReturnsNull_IfNotSet()
         {

--- a/test/ServiceStack.Request.Correlation.Tests/Properties/AssemblyInfo.cs
+++ b/test/ServiceStack.Request.Correlation.Tests/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using Xunit;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -33,3 +34,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: CollectionBehavior(MaxParallelThreads = 1)]

--- a/test/ServiceStack.Request.Correlation.Tests/RequestCorrelationFeatureTests.cs
+++ b/test/ServiceStack.Request.Correlation.Tests/RequestCorrelationFeatureTests.cs
@@ -11,25 +11,32 @@ namespace ServiceStack.Request.Correlation.Tests
     using Testing;
     using Web;
     using Xunit;
-
+    
     [Collection("RequestCorrelationTests")]
-    public class RequestCorrelationFeatureTests
+    public class RequestCorrelationFeatureTests : IDisposable
     {
         private readonly RequestCorrelationFeature feature;
         private readonly IIdentityGenerator generator;
         private readonly string newId = Guid.NewGuid().ToString();
+        private readonly ServiceStackHost appHost;
 
         public RequestCorrelationFeatureTests()
         {
+            appHost = new BasicAppHost().Init();
             generator = A.Fake<IIdentityGenerator>();
             A.CallTo(() => generator.GenerateIdentity()).Returns(newId);
             feature = new RequestCorrelationFeature { IdentityGenerator = generator };
         }
 
+        public void Dispose()
+        {
+            appHost.Dispose();
+        }
+
         [Fact]
         public void Register_AddsPreRequestFilter()
         {
-            var appHost = A.Fake<IAppHost>();
+//            var appHost = A.Fake<IAppHost>();
             appHost.PreRequestFilters.Count.Should().Be(0);
 
             feature.Register(appHost);
@@ -40,7 +47,7 @@ namespace ServiceStack.Request.Correlation.Tests
         [Fact]
         public void Register_AddsPreRequestFilter_AtPosition0()
         {
-            var appHost = A.Fake<IAppHost>();
+//            var appHost = A.Fake<IAppHost>();
             Action<IRequest, IResponse> myDelegate = (request, response) => { };
 
             // Add delegate at position 0
@@ -55,7 +62,7 @@ namespace ServiceStack.Request.Correlation.Tests
         [Fact]
         public void Register_AddsResponseFilter()
         {
-            var appHost = A.Fake<IAppHost>();
+//            var appHost = A.Fake<IAppHost>();
             appHost.GlobalResponseFilters.Count.Should().Be(0);
 
             feature.Register(appHost);

--- a/test/ServiceStack.Request.Correlation.Tests/ServiceGatewayFactoryBaseDecoratorTests.cs
+++ b/test/ServiceStack.Request.Correlation.Tests/ServiceGatewayFactoryBaseDecoratorTests.cs
@@ -9,8 +9,9 @@ namespace ServiceStack.Request.Correlation.Tests
     using Testing;
     using Xunit;
 
-    public class ServiceGatewayFactoryBaseDecoratorTests
+    public class ServiceGatewayFactoryBaseDecoratorTests : IDisposable
     {
+        private readonly ServiceStackHost appHost;
         private readonly ServiceGatewayFactoryBaseDecorator gateway;
         private readonly ServiceGatewayFactoryBase decorated;
         private const string HeaderName = "x-correlation-id";
@@ -18,8 +19,14 @@ namespace ServiceStack.Request.Correlation.Tests
 
         public ServiceGatewayFactoryBaseDecoratorTests()
         {
+            appHost = new BasicAppHost().Init();
             decorated = A.Fake<ServiceGatewayFactoryBase>();
             gateway = new ServiceGatewayFactoryBaseDecorator(HeaderName, decorated);
+        }
+
+        public void Dispose()
+        {
+            appHost.Dispose();
         }
 
         [Theory]

--- a/test/ServiceStack.Request.Correlation.Tests/ServiceStack.Request.Correlation.Tests.csproj
+++ b/test/ServiceStack.Request.Correlation.Tests/ServiceStack.Request.Correlation.Tests.csproj
@@ -46,25 +46,20 @@
       <HintPath>..\..\src\packages\AutoFixture.3.44.0\lib\net40\Ploeh.AutoFixture.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="ServiceStack, Version=4.0.56.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\src\packages\ServiceStack.4.0.56\lib\net40\ServiceStack.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ServiceStack, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\ServiceStack.5.0.2\lib\net45\ServiceStack.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Client, Version=4.0.56.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\src\packages\ServiceStack.Client.4.0.56\lib\net40\ServiceStack.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ServiceStack.Client, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\ServiceStack.Client.5.0.2\lib\net45\ServiceStack.Client.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Common, Version=4.0.56.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\src\packages\ServiceStack.Common.4.0.56\lib\net40\ServiceStack.Common.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ServiceStack.Common, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\ServiceStack.Common.5.0.2\lib\net45\ServiceStack.Common.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Interfaces, Version=4.0.0.0, Culture=neutral, PublicKeyToken=e06fbc6124f57c43, processorArchitecture=MSIL">
-      <HintPath>..\..\src\packages\ServiceStack.Interfaces.4.0.56\lib\portable-wp80+sl5+net40+win8+wpa81+monotouch+monoandroid+xamarin.ios10\ServiceStack.Interfaces.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ServiceStack.Interfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\ServiceStack.Interfaces.5.0.2\lib\net45\ServiceStack.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="ServiceStack.Text, Version=4.0.56.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\src\packages\ServiceStack.Text.4.0.56\lib\net40\ServiceStack.Text.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ServiceStack.Text, Version=5.0.0.0, Culture=neutral, PublicKeyToken=02c12cbda47e6587, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\ServiceStack.Text.5.0.2\lib\net45\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/test/ServiceStack.Request.Correlation.Tests/packages.config
+++ b/test/ServiceStack.Request.Correlation.Tests/packages.config
@@ -3,11 +3,11 @@
   <package id="AutoFixture" version="3.44.0" targetFramework="net452" />
   <package id="FakeItEasy" version="1.25.3" targetFramework="net452" />
   <package id="FluentAssertions" version="4.2.2" targetFramework="net452" />
-  <package id="ServiceStack" version="4.0.56" targetFramework="net452" />
-  <package id="ServiceStack.Client" version="4.0.56" targetFramework="net452" />
-  <package id="ServiceStack.Common" version="4.0.56" targetFramework="net452" />
-  <package id="ServiceStack.Interfaces" version="4.0.56" targetFramework="net452" />
-  <package id="ServiceStack.Text" version="4.0.56" targetFramework="net452" />
+  <package id="ServiceStack" version="5.0.2" targetFramework="net452" />
+  <package id="ServiceStack.Client" version="5.0.2" targetFramework="net452" />
+  <package id="ServiceStack.Common" version="5.0.2" targetFramework="net452" />
+  <package id="ServiceStack.Interfaces" version="5.0.2" targetFramework="net452" />
+  <package id="ServiceStack.Text" version="5.0.2" targetFramework="net452" />
   <package id="xunit" version="2.1.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net452" />


### PR DESCRIPTION
Hey,
we are using your request log feature which uses the request correlation. we actually want to upgrade to v5, which is not possible because of `ServiceStack.Server [4.0.45, 5)`.

so first PR here to upgrade. some things to note:

the tests weren't running anymore because `HttpMockRequest `creates a `HttpMockResponse` in the constructor which was asserting the `AppHost` singleton to be there. An `AppHost` is needed now, didn't find a way around it. Feel free to correct me if there is a better way around it.

Since `AppHost` is singleton and xunit runs tests in parallel I had to choose between:

a) `using (var appHost = new BasicAppHost().Init()) { ... }` in every test method
b) disable parallelization

i took b) because it's a small project, tests are already fast enough. not the most proud decision I had to take, but we simply have to accept the nature of AppHost singleton when using SS.

hope that's ok.

in http://docs.servicestack.net/releases/v5.0.0#enhancement-releases demis mentions the version strategy. so i did a little more optimistic version restriction `[4.0.56, 5.1)`.